### PR TITLE
Add FORECAST_URL configuration for server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Copy to .env and replace values
+
 DATABASE_URL=postgres://user:password@localhost:5432/officebooking
 # Used by both the API server and forecast service
-
+FORECAST_URL=http://localhost:8000
 
 # Optional: send email alerts for busy days
 SENDGRID_API_KEY=your-sendgrid-key

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -6,6 +6,7 @@ Express API for the Office Booking app. It reads configuration from `.env` in th
 - `DATABASE_URL` – Postgres connection string
 - `SENDGRID_API_KEY` and `ALERT_EMAIL` – optional email alerts
 - `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM`, `ALERT_PHONE` – optional SMS alerts
+- `FORECAST_URL` – base URL for the forecast service (defaults to `http://localhost:8000`)
 - `OPENAI_API_KEY` – enables the `/chatbot` endpoint
 
 ## Development

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -30,6 +30,7 @@ function createApp() {
   const twilioToken = process.env.TWILIO_AUTH_TOKEN;
   const twilioFrom = process.env.TWILIO_FROM;
   const alertPhone = process.env.ALERT_PHONE;
+  const forecastUrl = process.env.FORECAST_URL || 'http://localhost:8000';
 
   // Middleware
   app.use(express.json());
@@ -305,7 +306,7 @@ async function sendAlertSms(alerts) {
 
 app.get('/alerts', async (req, res) => {
   try {
-    const fRes = await fetch('http://localhost:8000/forecast');
+    const fRes = await fetch(`${forecastUrl}/forecast`);
     const fData = await fRes.json();
     const { rows } = await pool.query('SELECT COUNT(*) FROM desks');
     const totalDesks = Number(rows[0].count);
@@ -323,7 +324,7 @@ app.get('/alerts', async (req, res) => {
 // Proxy forecast data from the Python service
 app.get('/forecast', async (req, res) => {
   try {
-    const fRes = await fetch('http://localhost:8000/forecast');
+    const fRes = await fetch(`${forecastUrl}/forecast`);
     const data = await fRes.json();
     res.json(data);
   } catch (err) {


### PR DESCRIPTION
## Summary
- add `FORECAST_URL` variable to server
- update calls to use `${forecastUrl}/forecast`
- document the variable in server README and env example

## Testing
- `npm --workspace=packages/server ci`
- `npm --workspace=packages/server test`

------
https://chatgpt.com/codex/tasks/task_e_6855d6a67344832ea528f0ccd8bafdbc