### PR TITLE
Secure API routes with JWT auth

### DIFF
--- a/packages/server/__tests__/bookings.test.js
+++ b/packages/server/__tests__/bookings.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+jest.mock('../auth', () => ({ checkJwt: (req, res, next) => next() }));
 const { createApp } = require('../index');
 const db = require('../db');
 

--- a/packages/server/__tests__/desks.test.js
+++ b/packages/server/__tests__/desks.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+jest.mock('../auth', () => ({ checkJwt: (req, res, next) => next() }));
 const { createApp } = require('../index');
 const db = require('../db');
 

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -13,6 +13,7 @@ const {
   deleteBooking,
   deleteDesk,
 } = require('./db');
+const { checkJwt } = require('./auth');
 
 function createApp() {
   const app = express();
@@ -48,6 +49,9 @@ function createApp() {
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
+
+// Require auth for all following routes
+app.use(checkJwt);
 
 // Desks
 app.get('/desks', async (req, res) => {


### PR DESCRIPTION
## Summary
- add `checkJwt` middleware import
- enforce authentication on API routes
- mock auth middleware in tests

## Testing
- `npm --workspace=packages/server test`


------
https://chatgpt.com/codex/tasks/task_e_6855d8818930832e870753b963ab0e2b