### PR TITLE
Add events and RSVP endpoints

### DIFF
--- a/packages/server/__tests__/events.test.js
+++ b/packages/server/__tests__/events.test.js
@@ -1,0 +1,53 @@
+const request = require('supertest');
+jest.mock('../auth', () => ({ checkJwt: (req, res, next) => next() }));
+const { createApp } = require('../index');
+const db = require('../db');
+
+jest.mock('../db', () => {
+  const mockPool = { query: jest.fn() };
+  return { pool: mockPool, init: jest.fn(), logEvent: jest.fn() };
+});
+
+beforeEach(() => {
+  db.pool.query.mockReset();
+});
+
+test('GET /events returns rows', async () => {
+  db.pool.query.mockResolvedValue({ rows: [{ id: 1 }] });
+  const app = createApp();
+  const res = await request(app).get('/events');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual([{ id: 1 }]);
+  expect(db.pool.query).toHaveBeenCalledWith('SELECT * FROM events ORDER BY event_time');
+});
+
+test('POST /events validates fields', async () => {
+  const app = createApp();
+  const res = await request(app).post('/events').send({});
+  expect(res.statusCode).toBe(400);
+});
+
+test('POST /events creates event', async () => {
+  db.pool.query.mockResolvedValue({ rows: [{ id: 1 }] });
+  const app = createApp();
+  const payload = { title: 't', event_time: 'now' };
+  const res = await request(app).post('/events').send(payload);
+  expect(res.statusCode).toBe(201);
+  expect(res.body).toEqual({ id: 1 });
+  expect(db.pool.query).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO events'),
+    ['t', null, 'now', 'public']
+  );
+});
+
+test('POST /events/:id/rsvp creates rsvp', async () => {
+  db.pool.query.mockResolvedValue({ rows: [{ id: 1 }] });
+  const app = createApp();
+  const res = await request(app).post('/events/1/rsvp').send({ user_id: 'u1', status: 'yes' });
+  expect(res.statusCode).toBe(201);
+  expect(res.body).toEqual({ id: 1 });
+  expect(db.pool.query).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO rsvps'),
+    ['1', 'u1', 'yes']
+  );
+});

--- a/packages/server/db.js
+++ b/packages/server/db.js
@@ -46,6 +46,19 @@ async function init() {
       timestamp TIMESTAMPTZ DEFAULT NOW(),
       payload JSONB
     );
+    CREATE TABLE IF NOT EXISTS events (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL,
+      description TEXT,
+      event_time TIMESTAMPTZ NOT NULL,
+      visibility VARCHAR(20) DEFAULT 'public'
+    );
+    CREATE TABLE IF NOT EXISTS rsvps (
+      id SERIAL PRIMARY KEY,
+      event_id INTEGER REFERENCES events(id) ON DELETE CASCADE,
+      user_id VARCHAR(255) NOT NULL,
+      status VARCHAR(20)
+    );
     CREATE OR REPLACE VIEW daily_utilization AS
       SELECT date_trunc('day', start_time) AS day, COUNT(*) AS bookings
       FROM bookings


### PR DESCRIPTION
## Summary
- add `events` and `rsvps` tables on server startup
- implement CRUD routes for `/events` and `POST /events/:id/rsvp`
- test new endpoints

## Testing
- `npm --workspace=packages/server install`
- `npm --workspace=packages/server test`

------
https://chatgpt.com/codex/tasks/task_e_6855d9934e88832ea9b9c7df5be68bd5