### PR TITLE
Add events page with RSVP support

### DIFF
--- a/packages/web/src/App.jsx
+++ b/packages/web/src/App.jsx
@@ -5,6 +5,7 @@ import DesksPage from './pages/DesksPage.jsx';
 import BookingsPage from './pages/BookingsPage.jsx';
 import AnalyticsPage from './pages/AnalyticsPage.jsx';
 import AlertsPage from './pages/AlertsPage.jsx';
+import EventsPage from './pages/EventsPage.jsx';
 import UsersPage from './pages/UsersPage.jsx';
 import SettingsPage from './pages/SettingsPage.jsx';
 import Layout from './components/Layout.jsx';
@@ -20,6 +21,7 @@ export default function App() {
           <Route path="/bookings" element={<BookingsPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/alerts" element={<AlertsPage />} />
+          <Route path="/events" element={<EventsPage />} />
           <Route path="/users" element={<UsersPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>

--- a/packages/web/src/components/CreateEventModal.jsx
+++ b/packages/web/src/components/CreateEventModal.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Modal from './ui/Modal.jsx';
+import Button from './ui/Button.jsx';
+import { Box, TextField, Typography } from '@mui/material';
+
+export default function CreateEventModal({ open, onClose, form, setForm, onSubmit }) {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Typography variant="h6" gutterBottom>
+        Create Event
+      </Typography>
+      <Box component="form" onSubmit={onSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField
+          label="Title"
+          size="small"
+          fullWidth
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+        <TextField
+          label="Description"
+          size="small"
+          multiline
+          rows={3}
+          fullWidth
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+        />
+        <TextField
+          type="datetime-local"
+          label="Event Time"
+          size="small"
+          fullWidth
+          InputLabelProps={{ shrink: true }}
+          value={form.event_time}
+          onChange={(e) => setForm({ ...form, event_time: e.target.value })}
+        />
+        <Button type="submit" fullWidth>
+          Create Event
+        </Button>
+      </Box>
+    </Modal>
+  );
+}

--- a/packages/web/src/components/Layout.jsx
+++ b/packages/web/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Home, Calendar, BarChart2 } from 'lucide-react';
+import { Home, Calendar, BarChart2, CalendarDays } from 'lucide-react';
 import {
   AppBar,
   Toolbar,
@@ -19,6 +19,7 @@ const navItems = [
   { name: 'Dashboard', icon: <Home size={18} />, href: '/dashboard' },
   { name: 'Book a Desk', icon: <Calendar size={18} />, href: '/bookings' },
   { name: 'Forecast', icon: <BarChart2 size={18} />, href: '/analytics' },
+  { name: 'Events', icon: <CalendarDays size={18} />, href: '/events' },
 ];
 
 export default function Layout({ children }) {

--- a/packages/web/src/components/RsvpModal.jsx
+++ b/packages/web/src/components/RsvpModal.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Modal from './ui/Modal.jsx';
+import Button from './ui/Button.jsx';
+import { Box, Typography } from '@mui/material';
+
+export default function RsvpModal({ open, onClose, event, onSelect }) {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Typography variant="h6" gutterBottom>
+        RSVP to {event?.title}
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+        <Button onClick={() => onSelect('yes')}>Yes</Button>
+        <Button onClick={() => onSelect('maybe')}>Maybe</Button>
+        <Button onClick={() => onSelect('no')}>No</Button>
+      </Box>
+    </Modal>
+  );
+}

--- a/packages/web/src/pages/EventsPage.jsx
+++ b/packages/web/src/pages/EventsPage.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '../components/Layout.jsx';
+import Button from '../components/ui/Button.jsx';
+import CreateEventModal from '../components/CreateEventModal.jsx';
+import RsvpModal from '../components/RsvpModal.jsx';
+import {
+  Box,
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Paper,
+} from '@mui/material';
+
+export default function EventsPage() {
+  const [events, setEvents] = useState([]);
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState({ title: '', description: '', event_time: '' });
+  const [rsvpEvent, setRsvpEvent] = useState(null);
+
+  async function load() {
+    const res = await fetch('/events');
+    if (res.ok) setEvents(await res.json());
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function submitCreate(e) {
+    e.preventDefault();
+    const res = await fetch('/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      setShowCreate(false);
+      setForm({ title: '', description: '', event_time: '' });
+      load();
+    }
+  }
+
+  async function sendRsvp(status) {
+    if (!rsvpEvent) return;
+    const res = await fetch(`/events/${rsvpEvent.id}/rsvp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: 'anon', status }),
+    });
+    if (res.ok) setRsvpEvent(null);
+  }
+
+  return (
+    <Layout>
+      <Box>
+        <Typography variant="h5" gutterBottom>
+          Events
+        </Typography>
+
+        <Box mb={2}>
+          <Button onClick={() => setShowCreate(true)}>New Event</Button>
+        </Box>
+
+        <Paper sx={{ overflowX: 'auto' }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Title</TableCell>
+                <TableCell>Date</TableCell>
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {events.map((ev) => (
+                <TableRow key={ev.id} hover>
+                  <TableCell>{ev.title}</TableCell>
+                  <TableCell>{new Date(ev.event_time).toLocaleString()}</TableCell>
+                  <TableCell>
+                    <Button onClick={() => setRsvpEvent(ev)} size="small">
+                      RSVP
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+
+        <CreateEventModal
+          open={showCreate}
+          onClose={() => setShowCreate(false)}
+          form={form}
+          setForm={setForm}
+          onSubmit={submitCreate}
+        />
+
+        <RsvpModal
+          open={!!rsvpEvent}
+          onClose={() => setRsvpEvent(null)}
+          event={rsvpEvent}
+          onSelect={sendRsvp}
+        />
+      </Box>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add `EventsPage` to show upcoming events
- create reusable `CreateEventModal` and `RsvpModal` components
- link new route in `App.jsx`
- add Events entry in the navigation

## Testing
- `npm --workspace packages/server test`
- `npm --workspace packages/web test`
- `npm --workspace packages/web run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6855da548f9c832e8c119763bc544a50