### PR TITLE
Disable JWT auth for local development

### DIFF
--- a/packages/server/auth.js
+++ b/packages/server/auth.js
@@ -1,19 +1,6 @@
-const { expressjwt: jwt } = require('express-jwt');
-const jwksRsa = require('jwks-rsa');
-
-const domain = process.env.AUTH0_DOMAIN;
-const audience = process.env.AUTH0_AUDIENCE;
-
-const checkJwt = jwt({
-  secret: jwksRsa.expressJwtSecret({
-    jwksUri: `https://${domain}/.well-known/jwks.json`,
-    cache: true,
-    rateLimit: true,
-    jwksRequestsPerMinute: 5,
-  }),
-  audience,
-  issuer: `https://${domain}/`,
-  algorithms: ['RS256'],
-});
+// Temporary stub; remove when JWT auth is re-enabled
+function checkJwt(req, res, next) {
+  next();
+}
 
 module.exports = { checkJwt };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,6 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.18.2",
-    "express-jwt": "^8.4.1",
-    "jwks-rsa": "^3.0.1",
     "pg": "^8.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- stub out JWT auth middleware to always allow requests
- remove unused `express-jwt` and `jwks-rsa` packages

## Testing
- `npm --workspace packages/server test`


------
https://chatgpt.com/codex/tasks/task_e_68564a02e51c832eb575daab16459944