### PR TITLE
Add booking time validation

### DIFF
--- a/packages/server/__tests__/bookings.test.js
+++ b/packages/server/__tests__/bookings.test.js
@@ -29,7 +29,12 @@ test('POST /bookings validates fields', async () => {
 test('POST /bookings detects conflict', async () => {
   db.pool.query.mockResolvedValueOnce({ rows: [{ id: 1 }] });
   const app = createApp();
-  const payload = { user_id: 'u1', desk_id: 1, start_time: 's', end_time: 'e' };
+  const payload = {
+    user_id: 'u1',
+    desk_id: 1,
+    start_time: '2023-01-01T10:00:00Z',
+    end_time: '2023-01-01T11:00:00Z'
+  };
   const res = await request(app).post('/bookings').send(payload);
   expect(res.statusCode).toBe(409);
 });
@@ -40,8 +45,36 @@ test('POST /bookings creates booking', async () => {
     .mockResolvedValueOnce({ rows: [] })
     .mockResolvedValueOnce({ rows: [{ id: 1 }] });
   const app = createApp();
-  const payload = { user_id: 'u1', desk_id: 1, start_time: 's', end_time: 'e' };
+  const payload = {
+    user_id: 'u1',
+    desk_id: 1,
+    start_time: '2023-01-01T10:00:00Z',
+    end_time: '2023-01-01T11:00:00Z'
+  };
   const res = await request(app).post('/bookings').send(payload);
   expect(res.statusCode).toBe(201);
   expect(res.body).toEqual({ id: 1 });
+});
+
+test('POST /bookings rejects invalid time range', async () => {
+  const app = createApp();
+  const payload = {
+    user_id: 'u1',
+    desk_id: 1,
+    start_time: '2023-01-02T10:00:00Z',
+    end_time: '2023-01-02T09:00:00Z'
+  };
+  const res = await request(app).post('/bookings').send(payload);
+  expect(res.statusCode).toBe(400);
+});
+
+test('PUT /bookings rejects invalid time range', async () => {
+  db.pool.query.mockResolvedValue({ rows: [{ desk_id: 1 }] });
+  const app = createApp();
+  const payload = {
+    start_time: '2023-01-02T10:00:00Z',
+    end_time: '2023-01-02T09:00:00Z'
+  };
+  const res = await request(app).put('/bookings/1').send(payload);
+  expect(res.statusCode).toBe(400);
 });

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -138,6 +138,10 @@ app.post('/bookings', async (req, res) => {
     return res.status(400).json({ error: 'missing fields' });
   }
 
+  if (new Date(start_time) >= new Date(end_time)) {
+    return res.status(400).json({ error: 'invalid time range' });
+  }
+
 
   const [blockConflicts, conflicts] = await Promise.all([
     pool.query(
@@ -183,6 +187,10 @@ app.put('/bookings/:id', async (req, res) => {
     (await pool.query('SELECT desk_id FROM bookings WHERE id=$1', [id])).rows[0]?.desk_id;
 
   if (!start || !end || !desk) return res.status(404).json({ error: 'booking not found' });
+
+  if (new Date(start) >= new Date(end)) {
+    return res.status(400).json({ error: 'invalid time range' });
+  }
 
   const [blockConflicts, conflicts] = await Promise.all([
     pool.query(


### PR DESCRIPTION
## Summary
- validate start_time < end_time on booking creation and updates
- test invalid booking time range for POST and PUT

## Testing
- `npm test --silent --prefix packages/server`

------
https://chatgpt.com/codex/tasks/task_e_68564ced8248832e82ddd7ae35ac4991