### PR TITLE
Implement layout locking and non-desk objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12121,6 +12121,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -12146,6 +12156,29 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -12162,6 +12195,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-rnd": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
+      "integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+      "license": "MIT",
+      "dependencies": {
+        "re-resizable": "6.11.2",
+        "react-draggable": "4.4.6",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-rnd/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
     },
     "node_modules/react-router": {
       "version": "6.30.1",
@@ -14363,6 +14417,7 @@
         "lucide-react": "^0.339.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-rnd": "^10.5.2",
         "react-router-dom": "^6.22.3",
         "recharts": "^2.8.0",
         "serve": "^14.2.0"

--- a/packages/server/__tests__/objects.test.js
+++ b/packages/server/__tests__/objects.test.js
@@ -1,0 +1,41 @@
+const request = require('supertest');
+jest.mock('../auth', () => ({ checkJwt: (req, res, next) => next() }));
+const { createApp } = require('../index');
+const db = require('../db');
+
+jest.mock('../db', () => {
+  const mockPool = { query: jest.fn() };
+  return { pool: mockPool, init: jest.fn(), logEvent: jest.fn() };
+});
+
+beforeEach(() => {
+  db.pool.query.mockReset();
+});
+
+test('GET /objects returns rows', async () => {
+  db.pool.query.mockResolvedValue({ rows: [{ id: 1 }] });
+  const app = createApp();
+  const res = await request(app).get('/api/objects');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual([{ id: 1 }]);
+  expect(db.pool.query).toHaveBeenCalledWith('SELECT * FROM objects ORDER BY id');
+});
+
+test('POST /objects validates fields', async () => {
+  const app = createApp();
+  const res = await request(app).post('/api/objects').send({ label: 'x' });
+  expect(res.statusCode).toBe(400);
+});
+
+test('POST /objects creates object', async () => {
+  db.pool.query.mockResolvedValue({ rows: [{ id: 1 }] });
+  const app = createApp();
+  const payload = { label: 'Kitchen', type: 'Kitchen', x: 1, y: 2, width: 3, height: 4 };
+  const res = await request(app).post('/api/objects').send(payload);
+  expect(res.statusCode).toBe(201);
+  expect(res.body).toEqual({ id: 1 });
+  expect(db.pool.query).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO objects'),
+    ['Kitchen', 'Kitchen', 1, 2, 3, 4]
+  );
+});

--- a/packages/server/db.js
+++ b/packages/server/db.js
@@ -19,6 +19,15 @@ async function init() {
       height INTEGER NOT NULL,
       status VARCHAR(20) DEFAULT 'available'
     );
+    CREATE TABLE IF NOT EXISTS objects (
+      id SERIAL PRIMARY KEY,
+      label VARCHAR(255) NOT NULL,
+      type VARCHAR(50) NOT NULL,
+      x INTEGER NOT NULL,
+      y INTEGER NOT NULL,
+      width INTEGER NOT NULL,
+      height INTEGER NOT NULL
+    );
     CREATE TABLE IF NOT EXISTS bookings (
       id SERIAL PRIMARY KEY,
       user_id VARCHAR(255) NOT NULL,

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -127,6 +127,50 @@ api.delete('/desks/:deskId/blocks/:blockId', async (req, res) => {
   res.json(rows[0]);
 });
 
+// Objects
+api.get('/objects', async (req, res) => {
+  const { rows } = await pool.query('SELECT * FROM objects ORDER BY id');
+  res.json(rows);
+});
+
+api.post('/objects', async (req, res) => {
+  const { label, type, x, y, width, height } = req.body;
+  if (!label || !type || [x, y, width, height].some((v) => typeof v !== 'number')) {
+    return res.status(400).json({ error: 'invalid object fields' });
+  }
+  const { rows } = await pool.query(
+    `INSERT INTO objects (label, type, x, y, width, height)
+     VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+    [label, type, x, y, width, height]
+  );
+  res.status(201).json(rows[0]);
+});
+
+api.put('/objects/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const { label, type, x, y, width, height } = req.body;
+  if (!label || !type || [x, y, width, height].some((v) => typeof v !== 'number')) {
+    return res.status(400).json({ error: 'invalid object fields' });
+  }
+  const { rows } = await pool.query(
+    `UPDATE objects SET label=$1, type=$2, x=$3, y=$4, width=$5, height=$6
+     WHERE id=$7 RETURNING *`,
+    [label, type, x, y, width, height, id]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'object not found' });
+  res.json(rows[0]);
+});
+
+api.delete('/objects/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const { rows } = await pool.query(
+    'DELETE FROM objects WHERE id=$1 RETURNING *',
+    [id]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'object not found' });
+  res.json(rows[0]);
+});
+
 // Bookings
 api.get('/bookings', async (req, res) => {
   const { start, end } = req.query;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,6 +20,7 @@
     "clsx": "^2.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-rnd": "^10.5.2",
     "recharts": "^2.8.0",
     "serve": "^14.2.0",
     "react-router-dom": "^6.22.3",


### PR DESCRIPTION
## Summary
- enlarge desk scale for easier interaction
- add ability to lock desk positions and save layout
- support custom objects on the floor plan
- expose `/objects` CRUD API
- test object endpoints

## Testing
- `npm --workspace=packages/server test`
- `npm --workspace=packages/web test`


------
https://chatgpt.com/codex/tasks/task_e_68565f82f93c832ea9b36a092cf6aeb1