### PR TITLE
Add chatbot widget and booking query support

### DIFF
--- a/packages/web/src/__tests__/App.test.jsx
+++ b/packages/web/src/__tests__/App.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, act, waitFor } from '@testing-library/react';
 import App from '../App.jsx';
+import { ChatProvider } from '../context/ChatContext.jsx';
 import '@testing-library/jest-dom';
 
 beforeAll(() => {
@@ -10,7 +11,11 @@ beforeAll(() => {
 
 test('renders heading', async () => {
   await act(async () => {
-    render(<App />);
+    render(
+      <ChatProvider>
+        <App />
+      </ChatProvider>
+    );
   });
   await waitFor(() => expect(global.fetch).toHaveBeenCalled());
   expect(screen.getByRole('heading', { name: /office booking/i })).toBeInTheDocument();

--- a/packages/web/src/__tests__/DashboardPage.test.jsx
+++ b/packages/web/src/__tests__/DashboardPage.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, act, waitFor } from '@testing-library/react';
 import DashboardPage from '../pages/DashboardPage.jsx';
+import { ChatProvider } from '../context/ChatContext.jsx';
 import '@testing-library/jest-dom';
 
 beforeAll(() => {
@@ -10,7 +11,11 @@ beforeAll(() => {
 
 test('renders dashboard heading', async () => {
   await act(async () => {
-    render(<DashboardPage />);
+    render(
+      <ChatProvider>
+        <DashboardPage />
+      </ChatProvider>
+    );
   });
   await waitFor(() => expect(global.fetch).toHaveBeenCalled());
   expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument();

--- a/packages/web/src/__tests__/SettingsPage.test.jsx
+++ b/packages/web/src/__tests__/SettingsPage.test.jsx
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import SettingsPage from '../pages/SettingsPage.jsx';
+import { ChatProvider } from '../context/ChatContext.jsx';
 import '@testing-library/jest-dom';
 
 test('renders settings heading', () => {
-  render(<SettingsPage />);
+  render(
+    <ChatProvider>
+      <SettingsPage />
+    </ChatProvider>
+  );
   expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument();
 });

--- a/packages/web/src/__tests__/UsersPage.test.jsx
+++ b/packages/web/src/__tests__/UsersPage.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, act, waitFor } from '@testing-library/react';
 import UsersPage from '../pages/UsersPage.jsx';
+import { ChatProvider } from '../context/ChatContext.jsx';
 import '@testing-library/jest-dom';
 
 beforeAll(() => {
@@ -10,7 +11,11 @@ beforeAll(() => {
 
 test('renders users heading', async () => {
   await act(async () => {
-    render(<UsersPage />);
+    render(
+      <ChatProvider>
+        <UsersPage />
+      </ChatProvider>
+    );
   });
   await waitFor(() => expect(global.fetch).toHaveBeenCalled());
   expect(screen.getByRole('heading', { name: /users/i })).toBeInTheDocument();

--- a/packages/web/src/components/Layout.jsx
+++ b/packages/web/src/components/Layout.jsx
@@ -14,6 +14,8 @@ import {
   Box,
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
+import ChatButton from './ChatButton.jsx';
+import ChatOverlay from './ChatOverlay.jsx';
 
 const navItems = [
   { name: 'Dashboard', icon: <Home size={18} />, href: '/dashboard' },
@@ -25,6 +27,7 @@ const navItems = [
 
 export default function Layout({ children }) {
   const [open, setOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
 
   const drawerWidth = 240;
 
@@ -89,6 +92,8 @@ export default function Layout({ children }) {
         <Toolbar />
         {children}
       </Box>
+      <ChatButton onClick={() => setChatOpen(true)} />
+      <ChatOverlay open={chatOpen} onClose={() => setChatOpen(false)} />
     </Box>
   );
 }

--- a/packages/web/src/index.jsx
+++ b/packages/web/src/index.jsx
@@ -4,13 +4,16 @@ import { CssBaseline } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import App from './App.jsx';
+import { ChatProvider } from './context/ChatContext.jsx';
 
 const root = createRoot(document.getElementById('root'));
 root.render(
   <React.Fragment>
     <CssBaseline />
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <App />
+      <ChatProvider>
+        <App />
+      </ChatProvider>
     </LocalizationProvider>
   </React.Fragment>
 );


### PR DESCRIPTION
## Summary
- enable chat overlay across the app
- add ChatProvider wrapper in the app entry
- allow filtering bookings by user or team
- enhance chatbot endpoint to answer booking queries
- update tests for new provider

## Testing
- `npm --workspace packages/web test --silent`
- `npm --workspace packages/server test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68566341d1d8832e8becb78683a5a993