### PR TITLE
Implement user dashboard features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2585,6 +2585,17 @@
         "@fullcalendar/core": "~6.1.17"
       }
     },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.10.tgz",
+      "integrity": "sha512-RVYevo5T4RUZzR8omlbnBwRCqVNJWKryzI0ZrFULyqIYggN6uPmMuB9GvbrTjDfKhsm438KQwwhJerg2lGh3xA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.10",
+        "react": "^16.7.0 || ^17 || ^18",
+        "react-dom": "^16.7.0 || ^17 || ^18"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6651,7 +6662,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0"
@@ -14127,6 +14138,7 @@
         "@emotion/styled": "^11.11.5",
         "@fullcalendar/core": "^6.1.10",
         "@fullcalendar/daygrid": "^6.1.10",
+        "@fullcalendar/react": "^6.1.10",
         "@mui/icons-material": "^5.14.8",
         "@mui/material": "^5.15.11",
         "@mui/x-date-pickers": "^6.16.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.11.5",
     "@fullcalendar/core": "^6.1.10",
     "@fullcalendar/daygrid": "^6.1.10",
+    "@fullcalendar/react": "^6.1.10",
     "@mui/icons-material": "^5.14.8",
     "@mui/material": "^5.15.11",
     "@mui/x-date-pickers": "^6.16.0",

--- a/packages/web/src/pages/DashboardPage.jsx
+++ b/packages/web/src/pages/DashboardPage.jsx
@@ -1,28 +1,153 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Card from '../components/ui/Card.jsx';
+import Button from '../components/ui/Button.jsx';
 import UtilizationChart from '../UtilizationChart.jsx';
-import { Box, Typography, Grid } from '@mui/material';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import {
+  Box,
+  Typography,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
 
 export default function DashboardPage() {
+  const [bookings, setBookings] = useState([]);
+  const [events, setEvents] = useState([]);
+  const [recommend, setRecommend] = useState(null);
+
+  async function load() {
+    const [bRes, eRes, rRes] = await Promise.all([
+      fetch('/api/bookings?user=anon'),
+      fetch('/api/events'),
+      fetch('/api/recommendation'),
+    ]);
+    if (bRes.ok) {
+      const data = await bRes.json();
+      const upcoming = data.filter(
+        (b) => new Date(b.start_time) > new Date()
+      );
+      setBookings(upcoming);
+    }
+    if (eRes.ok) setEvents(await eRes.json());
+    if (rRes.ok) setRecommend(await rRes.json());
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function cancel(id) {
+    await fetch(`/api/bookings/${id}`, { method: 'DELETE' });
+    load();
+  }
+
+  const calendarEvents = bookings.map((b) => ({
+    title: `Desk ${b.desk_id}`,
+    start: b.start_time,
+    end: b.end_time,
+  }));
+
   return (
     <Box>
       <Typography variant="h6" gutterBottom>
-        Dashboard
+        My Dashboard
       </Typography>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
-          <Card>
-            <UtilizationChart />
+          <Card sx={{ minHeight: 250 }}>
+            <Typography variant="subtitle1" gutterBottom>
+              Upcoming Bookings
+            </Typography>
+            <List dense>
+              {bookings.slice(0, 5).map((b) => (
+                <ListItem
+                  key={b.id}
+                  secondaryAction={
+                    <Button size="small" onClick={() => cancel(b.id)}>
+                      Cancel
+                    </Button>
+                  }
+                >
+                  <ListItemText
+                    primary={`Desk ${b.desk_id}`}
+                    secondary={`${new Date(b.start_time).toLocaleString()} - ${new Date(b.end_time).toLocaleString()}`}
+                  />
+                </ListItem>
+              ))}
+              {!bookings.length && (
+                <ListItem>
+                  <ListItemText primary="No upcoming bookings" />
+                </ListItem>
+              )}
+            </List>
           </Card>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Card>Upcoming bookings</Card>
+          <Card sx={{ minHeight: 250 }}>
+            <Typography variant="subtitle1" gutterBottom>
+              Calendar
+            </Typography>
+            <FullCalendar
+              plugins={[dayGridPlugin]}
+              initialView="dayGridMonth"
+              height={250}
+              events={calendarEvents}
+            />
+          </Card>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Card>Desk status overview</Card>
+          <Card sx={{ minHeight: 250 }}>
+            <Typography variant="subtitle1" gutterBottom>
+              Events
+            </Typography>
+            <List dense>
+              {events.slice(0, 5).map((ev) => (
+                <ListItem key={ev.id}>
+                  <ListItemText
+                    primary={ev.title}
+                    secondary={new Date(ev.event_time).toLocaleString()}
+                  />
+                  <Button
+                    size="small"
+                    onClick={() =>
+                      fetch(`/api/events/${ev.id}/rsvp`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ user_id: 'anon', status: 'yes' }),
+                      })
+                    }
+                  >
+                    RSVP
+                  </Button>
+                </ListItem>
+              ))}
+              {!events.length && (
+                <ListItem>
+                  <ListItemText primary="No upcoming events" />
+                </ListItem>
+              )}
+            </List>
+          </Card>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Card>Recent alerts</Card>
+          <Card sx={{ minHeight: 250 }}>
+            <Typography variant="subtitle1" gutterBottom>
+              Usage Stats
+            </Typography>
+            <UtilizationChart />
+          </Card>
+        </Grid>
+        <Grid item xs={12}>
+          <Card>
+            {recommend ? (
+              <Typography>Suggested Desk: {recommend.id}</Typography>
+            ) : (
+              <Typography>No recommendation available</Typography>
+            )}
+          </Card>
         </Grid>
       </Grid>
     </Box>


### PR DESCRIPTION
## Summary
- add `@fullcalendar/react` dependency
- build new dashboard page fetching bookings, events, recommendations
- render upcoming bookings list, calendar, events list, usage chart and desk suggestion

## Testing
- `npm --workspace packages/server test`
- `npm --workspace packages/web test`


------
https://chatgpt.com/codex/tasks/task_e_68566ac6fc80832e88d017576ee34638