### PR TITLE
Fix analytics heatmap colors

### DIFF
--- a/packages/web/src/components/CalendarHeatmap.jsx
+++ b/packages/web/src/components/CalendarHeatmap.jsx
@@ -6,7 +6,7 @@ import { Box } from '@mui/material';
 export default function CalendarHeatmapChart({ values, onClick }) {
   // values should be array of { date: 'YYYY-MM-DD', count: number }
   return (
-    <Box sx={{ '& .color-empty': { fill: '#e2e8f0' } }}>
+    <Box sx={{ width: '100%', '& .color-empty': { fill: '#e2e8f0' } }}>
       <CalendarHeatmap
         startDate={values.length ? values[0].date : new Date()}
         endDate={values.length ? values[values.length - 1].date : new Date()}

--- a/packages/web/src/global.css
+++ b/packages/web/src/global.css
@@ -57,3 +57,9 @@ body {
   box-shadow: var(--shadow-light), var(--shadow-dark);
   font-size: 14px;
 }
+
+/* heatmap color scale */
+.react-calendar-heatmap .color-scale-1 { fill: #bbf7d0; }
+.react-calendar-heatmap .color-scale-2 { fill: #86efac; }
+.react-calendar-heatmap .color-scale-3 { fill: #eab308; }
+.react-calendar-heatmap .color-scale-4 { fill: #dc2626; }


### PR DESCRIPTION
## Summary
- ensure calendar heatmap uses correct color classes
- add global styles for heatmap color scale

## Testing
- `npm test --prefix packages/web`
- `npm test --prefix packages/server`


------
https://chatgpt.com/codex/tasks/task_e_6856a069f03c832e84df002d957a1042