### PR TITLE
Add settings persistence and improved forecasting

### DIFF
--- a/packages/forecast/README.md
+++ b/packages/forecast/README.md
@@ -1,6 +1,7 @@
 # Forecast Service
 
 Simple FastAPI service that predicts bookings for the next week.
+The prediction is based on average bookings for each day of the week.
 It connects to the same Postgres database used by the server.
 
 Set `DATABASE_URL` in your environment and install the dependencies:

--- a/packages/forecast/app.py
+++ b/packages/forecast/app.py
@@ -29,10 +29,26 @@ def fetch_daily_counts(days=30):
 
 
 def compute_forecast(counts, horizon=7):
+    """Return a 7 day forecast based on day-of-week averages."""
     if not counts:
         return [0] * horizon
-    avg = sum(c[1] for c in counts) / len(counts)
-    return [round(avg) for _ in range(horizon)]
+
+    # group counts by day of week
+    dow_totals = {i: [] for i in range(7)}
+    for day, cnt in counts:
+        dow_totals[day.weekday()].append(cnt)
+
+    dow_avgs = {
+        dow: (sum(vals) / len(vals)) if vals else 0
+        for dow, vals in dow_totals.items()
+    }
+
+    start_date = datetime.utcnow().date() + timedelta(days=1)
+    preds = []
+    for i in range(horizon):
+        dow = (start_date + timedelta(days=i)).weekday()
+        preds.append(round(dow_avgs.get(dow, 0)))
+    return preds
 
 
 @app.get("/forecast")

--- a/packages/server/__tests__/settings.test.js
+++ b/packages/server/__tests__/settings.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+jest.mock('../auth', () => ({ checkJwt: (req, res, next) => next() }));
+const { createApp } = require('../index');
+const db = require('../db');
+
+jest.mock('../db', () => {
+  return {
+    pool: { query: jest.fn() },
+    init: jest.fn(),
+    logEvent: jest.fn(),
+    getUserSettings: jest.fn(),
+    saveUserProfile: jest.fn(),
+    saveUserIntegrations: jest.fn(),
+  };
+});
+
+beforeEach(() => {
+  db.getUserSettings.mockReset();
+  db.saveUserProfile.mockReset();
+  db.saveUserIntegrations.mockReset();
+});
+
+test('GET /settings returns data', async () => {
+  db.getUserSettings.mockResolvedValue({ name: 'A', email: 'a', slack_webhook: 's', google_api_key: 'g' });
+  const app = createApp();
+  const res = await request(app).get('/api/settings');
+  expect(res.statusCode).toBe(200);
+  expect(res.body.profile.name).toBe('A');
+  expect(db.getUserSettings).toHaveBeenCalled();
+});
+
+test('PUT /settings/profile saves data', async () => {
+  db.saveUserProfile.mockResolvedValue({ name: 'B', email: 'b' });
+  const app = createApp();
+  const res = await request(app).put('/api/settings/profile').send({ name: 'B', email: 'b' });
+  expect(res.statusCode).toBe(200);
+  expect(db.saveUserProfile).toHaveBeenCalled();
+});
+

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -9,6 +9,9 @@ const {
   logEvent,
   getUsers,
   updateUserRole,
+  getUserSettings,
+  saveUserProfile,
+  saveUserIntegrations,
   updateBooking,
   deleteBooking,
   deleteDesk,
@@ -420,6 +423,30 @@ api.put('/users/:id/role', requireAdmin, async (req, res) => {
   if (!role) return res.status(400).json({ error: 'missing role' });
   const user = await updateUserRole(id, role);
   res.json(user);
+});
+
+// Settings for the current user
+api.get('/settings', async (req, res) => {
+  const userId = req.headers['x-user-id'] || 'anon';
+  const data = await getUserSettings(userId);
+  res.json({
+    profile: { name: data?.name || '', email: data?.email || '' },
+    integrations: { slack: data?.slack_webhook || '', google: data?.google_api_key || '' },
+  });
+});
+
+api.put('/settings/profile', async (req, res) => {
+  const userId = req.headers['x-user-id'] || 'anon';
+  const { name = '', email = '' } = req.body;
+  const data = await saveUserProfile(userId, name, email);
+  res.json({ name: data.name, email: data.email });
+});
+
+api.put('/settings/integrations', async (req, res) => {
+  const userId = req.headers['x-user-id'] || 'anon';
+  const { slack = '', google = '' } = req.body;
+  const data = await saveUserIntegrations(userId, slack, google);
+  res.json({ slack: data.slack_webhook, google: data.google_api_key });
 });
 
 // Analytics

--- a/packages/web/src/__tests__/SettingsPage.test.jsx
+++ b/packages/web/src/__tests__/SettingsPage.test.jsx
@@ -1,13 +1,31 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import SettingsPage from '../pages/SettingsPage.jsx';
 import { ChatProvider } from '../context/ChatContext.jsx';
 import '@testing-library/jest-dom';
 
-test('renders settings heading', () => {
+beforeAll(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ profile: {}, integrations: {} }) })
+  );
+});
+
+test('renders settings heading and saves profile', async () => {
   render(
     <ChatProvider>
       <SettingsPage />
     </ChatProvider>
   );
+
   expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Bob' } });
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'bob@example.com' } });
+  fireEvent.click(screen.getByRole('button', { name: /save profile/i }));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+  expect(global.fetch.mock.calls[1][0]).toBe('/api/settings/profile');
+});
+
+afterAll(() => {
+  global.fetch.mockRestore();
 });

--- a/packages/web/src/pages/SettingsPage.jsx
+++ b/packages/web/src/pages/SettingsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Card from '../components/ui/Card.jsx';
 import Button from '../components/ui/Button.jsx';
 import { Box, Typography, TextField } from '@mui/material';
@@ -7,14 +7,31 @@ export default function SettingsPage() {
   const [profile, setProfile] = useState({ name: '', email: '' });
   const [integrations, setIntegrations] = useState({ slack: '', google: '' });
 
-  const saveProfile = e => {
+  useEffect(() => {
+    fetch('/api/settings')
+      .then(r => r.json())
+      .then(data => {
+        if (data.profile) setProfile(data.profile);
+        if (data.integrations) setIntegrations(data.integrations);
+      });
+  }, []);
+
+  const saveProfile = async e => {
     e.preventDefault();
-    console.log('save profile', profile);
+    await fetch('/api/settings/profile', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(profile)
+    });
   };
 
-  const saveIntegrations = e => {
+  const saveIntegrations = async e => {
     e.preventDefault();
-    console.log('save integrations', integrations);
+    await fetch('/api/settings/integrations', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(integrations)
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- improve forecast algorithm using day-of-week averages
- persist user settings and integration preferences
- expose new `/settings` API endpoints
- update Settings page to load and save through the API
- add unit tests for new endpoints and UI behaviour

## Testing
- `npm --workspace packages/server test`
- `npm --workspace packages/web test`


------
https://chatgpt.com/codex/tasks/task_e_6856a42aa3a8832e8298c7e9256977c3