### PR TITLE
Add dashboard events feed

### DIFF
--- a/packages/server/__tests__/events.test.js
+++ b/packages/server/__tests__/events.test.js
@@ -63,3 +63,12 @@ test('POST /events/:id/rsvp creates rsvp', async () => {
     ['1', 'u1', 'yes']
   );
 });
+
+test('GET /events/upcoming returns aggregated rows', async () => {
+  db.pool.query.mockResolvedValue({ rows: [{ id: 1 }] });
+  const app = createApp();
+  const res = await request(app).get('/api/events/upcoming');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual([{ id: 1 }]);
+  expect(db.pool.query).toHaveBeenCalledWith(expect.stringContaining('FROM events e'));
+});

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -340,6 +340,22 @@ api.get('/events', async (req, res) => {
   res.json(rows);
 });
 
+// Upcoming events with RSVP counts for the next 7 days
+api.get('/events/upcoming', async (req, res) => {
+  const { rows } = await pool.query(
+    `SELECT e.*,\n
+            COUNT(r.id) FILTER (WHERE r.status = 'yes')  AS yes_count,\n
+            COUNT(r.id) FILTER (WHERE r.status = 'maybe') AS maybe_count,\n
+            COUNT(r.id) FILTER (WHERE r.status = 'no')    AS no_count\n
+     FROM events e\n
+     LEFT JOIN rsvps r ON r.event_id = e.id\n
+     WHERE e.event_time >= NOW() AND e.event_time < NOW() + INTERVAL '7 days'\n
+     GROUP BY e.id\n
+     ORDER BY e.event_time`
+  );
+  res.json(rows);
+});
+
 api.get('/events/:id', async (req, res) => {
   const { id } = req.params;
   const { rows } = await pool.query('SELECT * FROM events WHERE id=$1', [id]);

--- a/packages/web/src/pages/DashboardPage.jsx
+++ b/packages/web/src/pages/DashboardPage.jsx
@@ -19,6 +19,7 @@ import { CalendarMonth, Cancel } from '@mui/icons-material';
 
 export default function DashboardPage() {
   const [bookings, setBookings] = useState([]);
+  const [events, setEvents] = useState([]);
   const [recommend, setRecommend] = useState(null);
   const [calendarDate, setCalendarDate] = useState(dayjs());
 
@@ -41,6 +42,10 @@ export default function DashboardPage() {
     (async () => {
       const rRes = await fetch('/api/recommendation');
       if (rRes.ok) setRecommend(await rRes.json());
+    })();
+    (async () => {
+      const eRes = await fetch('/api/events/upcoming');
+      if (eRes.ok) setEvents(await eRes.json());
     })();
   }, [calendarDate]);
 
@@ -114,6 +119,31 @@ export default function DashboardPage() {
               {!bookings.length && (
                 <ListItem>
                   <ListItemText primary="No upcoming bookings" />
+                </ListItem>
+              )}
+            </List>
+          </Card>
+        </Grid>
+
+        {/* Upcoming Events */}
+        <Grid item xs={12} md={4}>
+          <Card sx={{ boxShadow: 3 }}>
+            <Typography variant="h6" gutterBottom>
+              What's Happening This Week
+            </Typography>
+            <Divider sx={{ mb: 1 }} />
+            <List dense>
+              {events.map((ev) => (
+                <ListItem key={ev.id} sx={{ py: 1, px: 0 }}>
+                  <ListItemText
+                    primary={ev.title}
+                    secondary={`${dayjs(ev.event_time).format('ddd D MMM, HH:mm')} – ${ev.yes_count || 0} going`}
+                  />
+                </ListItem>
+              ))}
+              {!events.length && (
+                <ListItem>
+                  <ListItemText primary="No events this week" />
                 </ListItem>
               )}
             </List>


### PR DESCRIPTION
## Summary
- show upcoming events on dashboard
- provide new `/events/upcoming` API
- test upcoming events endpoint

## Testing
- `npm --workspace packages/server test`
- `npm --workspace packages/web test`


------
https://chatgpt.com/codex/tasks/task_e_6856acdd5954832e944c48c39aab98eb